### PR TITLE
Optional web hook notification for missing feature toggles

### DIFF
--- a/MogglesClient/NetCoreMogglesConfigurationManager.cs
+++ b/MogglesClient/NetCoreMogglesConfigurationManager.cs
@@ -104,6 +104,11 @@ namespace MogglesClient
         {
             return Configuration.GetSection(MogglesConfigurationKeys.RootSection)[MogglesConfigurationKeys.CacheRefreshQueue];
         }
+
+        public string GetNotificationWebHook()
+        {
+            return Configuration.GetSection(MogglesConfigurationKeys.RootSection)[MogglesConfigurationKeys.NotificationWebHook];
+        }
     }
 }
 #endif

--- a/MogglesClient/NetFullMogglesConfigurationManager.cs
+++ b/MogglesClient/NetFullMogglesConfigurationManager.cs
@@ -100,6 +100,11 @@ namespace MogglesClient
         {
             return ConfigurationManager.AppSettings[MogglesConfigurationKeys.CacheRefreshQueue];
         }
+
+        public string GetNotificationWebHook()
+        {
+            return ConfigurationManager.AppSettings[MogglesConfigurationKeys.NotificationWebHook];
+        }
     }
 }
 #endif

--- a/MogglesClient/PublicInterface/IMogglesConfigurationManager.cs
+++ b/MogglesClient/PublicInterface/IMogglesConfigurationManager.cs
@@ -20,5 +20,6 @@ namespace MogglesClient.PublicInterface
         string[] GetCustomAssemblies();
         string GetInstrumentationKey();
         string GetCacheRefreshQueue();
+        string GetNotificationWebHook();
     }
 }

--- a/MogglesClient/PublicInterface/MogglesClient.cs
+++ b/MogglesClient/PublicInterface/MogglesClient.cs
@@ -156,7 +156,7 @@ namespace MogglesClient.PublicInterface
             _featureToggleProvider = new MogglesServerProvider(_featureToggleLoggingService, _mogglesConfigurationManager);
             MogglesContainer.Register(_featureToggleProvider);
 
-            var notificationService = new NotificationService(_mogglesConfigurationManager);
+            var notificationService = new NotificationService(_mogglesConfigurationManager, _featureToggleLoggingService);
             MogglesContainer.Register<INotificationService>(notificationService);
         }
 

--- a/MogglesClient/PublicInterface/MogglesClient.cs
+++ b/MogglesClient/PublicInterface/MogglesClient.cs
@@ -2,6 +2,8 @@
 using MogglesClient.Logging;
 using System.Collections.Generic;
 using MogglesClient.Messaging.EnvironmentDetector;
+using MogglesClient.PublicInterface.Notifications;
+
 #if NETCORE
 using Microsoft.Extensions.Configuration;
 #endif
@@ -153,6 +155,9 @@ namespace MogglesClient.PublicInterface
 
             _featureToggleProvider = new MogglesServerProvider(_featureToggleLoggingService, _mogglesConfigurationManager);
             MogglesContainer.Register(_featureToggleProvider);
+
+            var notificationService = new NotificationService(_mogglesConfigurationManager);
+            MogglesContainer.Register<INotificationService>(notificationService);
         }
 
     }

--- a/MogglesClient/PublicInterface/MogglesConfigurationKeys.cs
+++ b/MogglesClient/PublicInterface/MogglesConfigurationKeys.cs
@@ -27,6 +27,7 @@
         internal static string InstrumentationKey = $"{RootSection}.ApplicationInsightsInstrumentationKey";
         internal static string CacheRefreshQueue = $"{RootSection}.CacheRefreshQueue";
         internal static string TokenSigningKey = $"{RootSection}.TokenSigningKey";
+        internal static string NotificationWebHook = $"{RootSection}.NotificationWebHook";
 
 #endif
 
@@ -45,6 +46,7 @@
         internal static string InstrumentationKey = "ApplicationInsightsInstrumentationKey";
         internal static string CacheRefreshQueue = "CacheRefreshQueue";
         internal static string TokenSigningKey = "TokenSigningKey";
+        internal static string NotificationWebHook = "NotificationWebHook";
 #endif
     }
 }

--- a/MogglesClient/PublicInterface/MogglesFeatureToggle.cs
+++ b/MogglesClient/PublicInterface/MogglesFeatureToggle.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using MogglesClient.PublicInterface.Notifications;
 
 namespace MogglesClient.PublicInterface
 {
@@ -22,6 +23,7 @@ namespace MogglesClient.PublicInterface
         {
             var featureToggleService = (MogglesToggleService)MogglesContainer.Resolve<MogglesToggleService>();
             var configurationManager = (IMogglesConfigurationManager)MogglesContainer.Resolve<IMogglesConfigurationManager>();
+            var notificationService = (INotificationService)MogglesContainer.Resolve<INotificationService>();
 
             if (configurationManager.IsApplicationInTestingMode())
             {
@@ -31,8 +33,13 @@ namespace MogglesClient.PublicInterface
             var featureToggleValue = featureToggleService.GetFeatureTogglesFromCache()
                 ?.FirstOrDefault(x => x.FeatureToggleName == _name);
 
-            return featureToggleValue?.IsEnabled ?? false;
-        }
+            if (featureToggleValue == null)
+            {
+                notificationService.TryNotifyMissingFeatureToggle(_name);
+                return false;
+            }
 
+            return featureToggleValue.IsEnabled;
+        }
     }
 }

--- a/MogglesClient/PublicInterface/Notifications/INotificationService.cs
+++ b/MogglesClient/PublicInterface/Notifications/INotificationService.cs
@@ -1,0 +1,7 @@
+﻿namespace MogglesClient.PublicInterface.Notifications
+{
+    public interface INotificationService
+    {
+        void TryNotifyMissingFeatureToggle(string featureFlagName);
+    }
+}

--- a/MogglesClient/PublicInterface/Notifications/Message.cs
+++ b/MogglesClient/PublicInterface/Notifications/Message.cs
@@ -1,0 +1,12 @@
+﻿namespace MogglesClient.PublicInterface.Notifications
+{
+    public class Message
+    {
+        public string text { get; }
+
+        public Message(string text)
+        {
+            this.text = text;
+        }
+    }
+}

--- a/MogglesClient/PublicInterface/Notifications/NotificationService.cs
+++ b/MogglesClient/PublicInterface/Notifications/NotificationService.cs
@@ -8,10 +8,12 @@ namespace MogglesClient.PublicInterface.Notifications
     public class NotificationService : INotificationService
     {
         private readonly IMogglesConfigurationManager _mogglesConfigurationManager;
+        private readonly IMogglesLoggingService _featureToggleLoggingService;
 
-        public NotificationService(IMogglesConfigurationManager mogglesConfigurationManager)
+        public NotificationService(IMogglesConfigurationManager mogglesConfigurationManager, IMogglesLoggingService featureToggleLoggingService)
         {
             _mogglesConfigurationManager = mogglesConfigurationManager;
+            _featureToggleLoggingService = featureToggleLoggingService;
         }
 
         public void TryNotifyMissingFeatureToggle(string featureFlagName)
@@ -37,9 +39,10 @@ namespace MogglesClient.PublicInterface.Notifications
                     client.PostAsync(string.Empty, new StringContent(serialized)).GetAwaiter().GetResult();
                 }
             }
-            catch
+            catch(Exception ex)
             {
-                // ignored
+                _featureToggleLoggingService.TrackException(ex, _mogglesConfigurationManager.GetApplicationName(), _mogglesConfigurationManager.GetEnvironment());
+
             }
         }
     }

--- a/MogglesClient/PublicInterface/Notifications/NotificationService.cs
+++ b/MogglesClient/PublicInterface/Notifications/NotificationService.cs
@@ -16,23 +16,30 @@ namespace MogglesClient.PublicInterface.Notifications
 
         public void TryNotifyMissingFeatureToggle(string featureFlagName)
         {
-            var webHook = _mogglesConfigurationManager.GetNotificationWebHook();
-
-            if (string.IsNullOrEmpty(webHook))
-                return;
-
-            using (var client = new HttpClient {BaseAddress = new Uri(webHook)})
+            try
             {
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                var webHook = _mogglesConfigurationManager.GetNotificationWebHook();
 
-                var application = _mogglesConfigurationManager.GetApplicationName();
-                var environment = _mogglesConfigurationManager.GetEnvironment();
+                if (string.IsNullOrEmpty(webHook))
+                    return;
 
-                var message = new Message($"For Application {application} and Environment {environment} the Feature Toggle with name {featureFlagName} is missing from Moggles.");
+                using (var client = new HttpClient {BaseAddress = new Uri(webHook)})
+                {
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-                var serialized = JsonConvert.SerializeObject(message);
+                    var application = _mogglesConfigurationManager.GetApplicationName();
+                    var environment = _mogglesConfigurationManager.GetEnvironment();
 
-                client.PostAsync(string.Empty, new StringContent(serialized)).GetAwaiter().GetResult();
+                    var message = new Message($"For Application {application} and Environment {environment} the Feature Toggle with name {featureFlagName} is missing from Moggles.");
+
+                    var serialized = JsonConvert.SerializeObject(message);
+
+                    client.PostAsync(string.Empty, new StringContent(serialized)).GetAwaiter().GetResult();
+                }
+            }
+            catch
+            {
+                // ignored
             }
         }
     }

--- a/MogglesClient/PublicInterface/Notifications/NotificationService.cs
+++ b/MogglesClient/PublicInterface/Notifications/NotificationService.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using Newtonsoft.Json;
+
+namespace MogglesClient.PublicInterface.Notifications
+{
+    public class NotificationService : INotificationService
+    {
+        private readonly IMogglesConfigurationManager _mogglesConfigurationManager;
+
+        public NotificationService(IMogglesConfigurationManager mogglesConfigurationManager)
+        {
+            _mogglesConfigurationManager = mogglesConfigurationManager;
+        }
+
+        public void TryNotifyMissingFeatureToggle(string featureFlagName)
+        {
+            var webHook = _mogglesConfigurationManager.GetNotificationWebHook();
+
+            if (string.IsNullOrEmpty(webHook))
+                return;
+
+            using (var client = new HttpClient {BaseAddress = new Uri(webHook)})
+            {
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+                var message = new Message($"Feature Toggle with name {featureFlagName} is missing from Moggles.");
+
+                var serialized = JsonConvert.SerializeObject(message);
+
+                client.PostAsync(string.Empty, new StringContent(serialized)).GetAwaiter().GetResult();
+            }
+        }
+    }
+}

--- a/MogglesClient/PublicInterface/Notifications/NotificationService.cs
+++ b/MogglesClient/PublicInterface/Notifications/NotificationService.cs
@@ -25,7 +25,10 @@ namespace MogglesClient.PublicInterface.Notifications
             {
                 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-                var message = new Message($"Feature Toggle with name {featureFlagName} is missing from Moggles.");
+                var application = _mogglesConfigurationManager.GetApplicationName();
+                var environment = _mogglesConfigurationManager.GetEnvironment();
+
+                var message = new Message($"For Application {application} and Environment {environment} the Feature Toggle with name {featureFlagName} is missing from Moggles.");
 
                 var serialized = JsonConvert.SerializeObject(message);
 


### PR DESCRIPTION
Added an optional notification service that will send a message through a webhook when a feature toggle is missing from moggles.
The webhook must be configured on the app using MogglesClient.